### PR TITLE
Don't pollute environment with undefined BABEL_ENV

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,13 @@ function withBabelEnv(setBabelEnv, fn) {
     process.env.BABEL_ENV = 'development'
   }
   const res = fn()
-  process.env.BABEL_ENV = oldBabelEnv
+  if (oldBabelEnv) {
+    // Reset the BABEL_ENV if it was previously set
+    process.env.BABEL_ENV = oldBabelEnv
+  } else {
+    // Otherwise delete it to prevent polluting the environment
+    delete process.env.BABEL_ENV
+  }
   return res
 }
 


### PR DESCRIPTION
Since the default value for `setBabelEnv` is `true`, the code attempts to set `process.env.BABEL_ENV` for transpiling the package, and restore it to the previous value when done. The problem is that when it wasn't defined in the first place it gets set to `undefined`, as in `process.env.BABEL_ENV === 'undefined'`. The causes a multitude of bizarre issues as you can imagine.

For an example of the problems this can cause see https://github.com/AtomLinter/linter-eslint/issues/921#issuecomment-303988518.

Fixes https://github.com/AtomLinter/linter-eslint/issues/921.