### PR TITLE
Fix incorrect sourceRoot

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,12 +42,13 @@ module.exports = {
   },
 
   transpile: function (source, filename, options, meta) {
+    const path = require('path')
     const babel = require('babel-core')
 
     const opts = options.babel || {}
     return withBabelEnv(options.setBabelEnv, function () {
       const result = babel.transform(source, Object.assign({}, opts, {
-        sourceRoot: meta.path,
+        sourceRoot: path.dirname(filename),
         filename: filename
       }))
       return {code: result.code, map: result.map}


### PR DESCRIPTION
Previously, sourceRoot was being set to the path of the package under test (`/test/package`). This caused all filenames to be appended directly to the sourceRoot (`./test/thing.js` resulted in `/test/package/thing.js` instead of `/test/package/test/thing.js`)