### PR TITLE
Allow setBabelEnv to name an alternative environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You may specify the following options as values of the `options` object in your 
 
 |Option|Default|Description|
 |--:|---|---|
-|`setBabelEnv`|`true`|Sets the `BABEL_ENV` environment variable to `"development"` when `atom.inDevMode()` or `atom.inSpecMode()` is true and `"production"` otherwise. Any value other than boolean `false` enables this feature. The feature returns `BABEL_ENV` to its prior value after transpilation finishes.|
+|`setBabelEnv`|`false`, `true` or a string|Sets the `BABEL_ENV` environment variable. When `true`, sets it to `"development"` when `atom.inDevMode()` or `atom.inSpecMode()` is true and `"production"` otherwise. When given as a string, uses the value of the environment variable of that name instead. The feature returns `BABEL_ENV` to its prior value after transpilation finishes.|
 |`babel`|`{}`|Options to pass as the second argument to `babel.transform` (the same options you can put in a `.babelrc`).|
 |`cacheKeyFiles`|`[]`|An array of files to include when determining whether or not to use the cache. For example, to force a recompile anytime your `.babelrc` changes, add `.babelrc` to this array.|
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,11 @@ function withBabelEnv(setBabelEnv, fn) {
   }
 
   const oldBabelEnv = process.env.BABEL_ENV
-  if (global.atom) {
+
+  if (setBabelEnv !== undefined && setBabelEnv !== true) {
+    const newBabelEnv = process.env[setBabelEnv] || 'development'
+    process.env.BABEL_ENV = newBabelEnv
+  } else if (global.atom) {
     process.env.BABEL_ENV = (atom.inDevMode() || atom.inSpecMode()) ? 'development' : 'production'
   } else {
     process.env.BABEL_ENV = 'development'


### PR DESCRIPTION
If `setBabelEnv` is set to a string, interpret it as the name of an environment variable to read as the `BABEL_ENV` to set.

---

In atom/github#1540, I was able to get Istanbul working with atom-mocha-test-runner by using `babel-plugin-istanbul` to generate instrumentation during babel transpilation. The instrumentation does have a performance cost, though, so we'd prefer to avoid generating it even for normal test runs. To do this I've gated it behind a babel environment:

```
# .babelrc
  "env": {
    "coverage": {
      "plugins": ["istanbul"]
    }
  }
```

But, I have no way to trigger this environment _only_ for `npm run test:coverage` executations _without_ disabling `setBabelEnv` entirely, which risks defaulting to `development` if an end user happens to have `NODE_ENV=development` set in their environment. With this in place I'll be able to use `ATOM_GITHUB_BABEL_ENV=coverage` or the like to accomplish this.